### PR TITLE
Display number of active opportunities on charity details

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -150,7 +150,7 @@ function App() {
             </ChooseAnOpportunity>
           </Route>
           <Route path="/charities/:charityName"
-            children={<CharityDetails charities={allCharities} />} />
+            children={<CharityDetails charities={allCharities} opportunities={allOpportunities} />} />
           <Route path="/charities">
             <Charities>
               {allCharities.map(charity => <CharityCard {...charity} key={charity.charityName} />)}

--- a/src/components/CharityDetails/CharityDetails.js
+++ b/src/components/CharityDetails/CharityDetails.js
@@ -3,13 +3,14 @@ import axios from 'axios';
 import { useParams } from "react-router-dom";
 import "./CharityDetails.css"
 
-function CharityDetails({ charities }) {
+function CharityDetails({ charities, opportunities }) {
 
     const { charityName } = useParams();
-    const charity = charities.find(item => item.charityName === charityName);
+    const charity = charities.find(item => item.charityName === charityName)
+    const numActiveProjects = opportunities.filter((opportunity) => opportunity.charity === charity.charityName).length
+    // get comments for this charity
     const apiUrl = process.env.REACT_APP_APIURL;
     const [comments, setComments] = useState([]);
-
     useEffect(() => {
         axios.get(`${apiUrl}/charities/${charity.charityId}/comments`)
             .then(response => setComments(response.data))
@@ -47,8 +48,7 @@ function CharityDetails({ charities }) {
                         <img src={charity.imageUrl} width="100%" alt="" />
                     </div>
                     <div className="col-12 col-md-7">
-                        <h4>Active Projects: <span className="badge badge-danger">{charity.numActiveProjects}</span></h4>
-                        <h4>Completed Projects: <span className="badge charity-details__badge">{charity.numCompletedProjects}</span></h4>
+                        <h4>Active Projects: <span className="badge badge-danger">{numActiveProjects}</span></h4>
                         <hr />
                         <h5>Description</h5>
                         <p>{charity.charityDescription}</p>


### PR DESCRIPTION
Minor change to display the number of active opportunities on the charity details page. Also removes the unused 'completed projects' item. 